### PR TITLE
[WOLMAI-916] Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -9,7 +9,7 @@
 # Auto-regeneration has been disabled (see updates.yml / update-template.yml) so
 # this change persists. Re-running the Upptime template update will revert it.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -36,12 +36,12 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Generate graphs
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "graphs"
         env:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -9,7 +9,7 @@
 # Auto-regeneration has been disabled (see updates.yml / update-template.yml) so
 # this change persists. Re-running the Upptime template update will revert it.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -36,12 +36,12 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "response-time"
         env:

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -9,7 +9,7 @@
 # The "Update template" step has been removed so that editing .upptimerc.yml no
 # longer regenerates (and reverts) these customised workflows.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -37,19 +37,19 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Update response time
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "response-time"
         env:
           GH_PAT: ${{ steps.app-token.outputs.token }}
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "readme"
         env:
@@ -60,7 +60,7 @@ jobs:
           workflow: Graphs CI
           token: ${{ steps.app-token.outputs.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "site"
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -9,7 +9,7 @@
 # Auto-regeneration has been disabled (see updates.yml / update-template.yml) so
 # this change persists. Re-running the Upptime template update will revert it.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -37,12 +37,12 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Generate site
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "site"
         env:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -9,7 +9,7 @@
 # Auto-regeneration has been disabled (see updates.yml / update-template.yml) so
 # this change persists. Re-running the Upptime template update will revert it.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -36,12 +36,12 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Update summary in README
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "readme"
         env:

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -9,7 +9,7 @@
 # This job is left available via manual dispatch only - run it knowingly, and
 # re-apply the app-token customisation afterwards.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -34,7 +34,7 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -9,7 +9,7 @@
 # workflows. This job is left available via manual dispatch only - run it
 # knowingly, and re-apply the app-token customisation afterwards.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -34,7 +34,7 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -9,7 +9,7 @@
 # Auto-regeneration has been disabled (see updates.yml / update-template.yml) so
 # this change persists. Re-running the Upptime template update will revert it.
 #
-# 🔼 Upptime @v1.41.3
+# 🔼 Upptime @v1.43.12
 # GitHub-powered open-source uptime monitor and status page by Anand Chowdhary
 
 # * Source: https://github.com/upptime/upptime
@@ -36,12 +36,12 @@ jobs:
           app-id: ${{ vars.EFFECT_CI_APP_ID }}
           private-key: ${{ secrets.EFFECT_CI_PRIVATE_KEY }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
       - name: Check endpoint status
-        uses: upptime/uptime-monitor@v1.41.3
+        uses: upptime/uptime-monitor@v1.43.12
         with:
           command: "update"
         env:


### PR DESCRIPTION
### Description

Brings the GitHub Actions referenced by the Upptime workflows up to their latest versions.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v4` | `v7` |
| `upptime/uptime-monitor` | `v1.41.3` | `v1.43.12` |

Already on their latest major, so unchanged: `actions/create-github-app-token@v3` (v3.2.0), `peaceiris/actions-gh-pages@v4` (v4.1.0), `benc-uk/workflow-dispatch@v1` (v1.3.2).

24 line changes across 8 workflow files: 8 `checkout` refs, 8 `uptime-monitor` refs, and the 8 `# 🔼 Upptime @v1.41.3` header comments updated to match so they do not go stale.

**Motivation**

- `actions/checkout@v4` targets Node.js 20, which is deprecated. Runs currently emit `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4`. v5 moved to Node 24.
- The Upptime monitor was 21 patch releases behind.

**Left unchanged**

The two `@master` references: `upptime/updates@master` in `updates.yml` and `upptime/uptime-monitor@master` in `update-template.yml`. Both float already, both are manual-dispatch only, and both regenerate every workflow from the upstream template, which would revert the Effect CI Bot authentication these files carry.

**Dependencies**

None. This repo has no `package.json`, so there is nothing to install.

### Issue ticket number and link

https://effectdigital.atlassian.net/browse/WOLMAI-916

### Related Pull Requests

None.

### Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Minor Update (small non-breaking change to text content or style which doesn't qualify as new functionality)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [x] Scheduled Maintenance (monthly update of third party packages and/or CMS version)
- [ ] Documentation Update (a documentation amendment was required in addition to functionality)

### How Has This Been Tested?

- [x] `actionlint .github/workflows/*.yml` passes with no findings across all eight workflow files
- [x] Confirmed every updated ref resolves to a real tag SHA via the GitHub API (`actions/checkout@v7` to `3d3c42e`, `upptime/uptime-monitor@v1.43.12` to `6e7c186`)
- [x] Read the `checkout` v5, v6 and v7 release notes for breaking changes. The one that could apply is v7.0.0 blocking fork-PR checkout for `pull_request_target` and `workflow_run`. This repo uses neither trigger
- [x] Read the Upptime v1.42.0 and v1.43.0 release notes. v1.42.0 added a generated-workflow secret allowlist, which affects only workflows regenerated from the upstream template. These workflows are hand-maintained and set `SECRETS_CONTEXT` in the file, so there is no runtime change
- [x] Diffed `src/helpers/secrets.ts` between v1.41.3 and v1.43.12 to confirm the `GH_PAT` and `SECRETS_CONTEXT` precedence behaviour holds

To reproduce:

```bash
brew install actionlint   # if not already present
actionlint .github/workflows/*.yml
```

After merge, `Uptime CI` runs every 5 minutes, so a green run on `main` confirms `checkout@v7` and the new monitor version in the real environment. `Static Site CI` runs daily at 01:00, or trigger it via `workflow_dispatch` to check the Pages deploy sooner.

**Reviewer note:** this is an engine upgrade, not just CI tooling. It lands after a permissions fix for the `effectdev` account that restored Slack notifications, so if anything looks wrong after the next incident, check the monitor version first. The bump does **not** fix the unguarded `octokit.issues.addAssignees` call behind that outage. In v1.43.12 it sits at `update.ts:650`, ahead of `sendNotification` and outside any try/catch, so the same failure returns if that account loses write access again.

### Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have provided a demo link, video, or screenshots if available. Not applicable, there is no user-facing or visual change
- [x] I have commented my code, particularly in hard-to-understand areas. The Effect Digital customisation headers covering the `@master` decision and the app-token authentication stay in place, with their version markers updated
- [ ] If it is a core feature, I have added thorough tests. Not applicable, this is a version bump with no new logic. Validated with `actionlint` as above
- [x] I have made corresponding changes to the documentation (where applicable). The in-file `# 🔼 Upptime @v1.41.3` version markers now read `v1.43.12`
